### PR TITLE
META-31: Fix Rush & Correct Guess Timer

### DIFF
--- a/src/components/NoteIdentification.tsx
+++ b/src/components/NoteIdentification.tsx
@@ -69,20 +69,8 @@ const NoteIdentification: React.FC<NoteIdentificationProps> = ({ onGuessAttempt,
 
     onGuessAttempt?.(attempt);
     setFeedback(`Time's up! The correct answer was ${currentNote.note}`);
+    startTimeout();
 
-    // Set timeout state to prevent overlapping operations
-    setIsInTimeout(true);
-
-    // Auto-advance to next note
-    const advanceTime = Math.min(autoAdvanceSpeed, 2); // Max 2 seconds for timeout
-    setTimeout(() => {
-      setIsInTimeout(false);
-
-      // Start new round
-      if (startNewRoundRef.current) {
-        startNewRoundRef.current();
-      }
-    }, advanceTime * 1000);
   }, [currentNote, onGuessAttempt, autoAdvanceSpeed, isGameCompleted]);
 
   const { timeRemaining, isTimerActive, startTimer, stopTimer, resetTimer } = useGameTimer({
@@ -120,6 +108,15 @@ const NoteIdentification: React.FC<NoteIdentificationProps> = ({ onGuessAttempt,
     audioEngine.playNote(currentNote, noteDuration);
     setTimeout(() => setIsPlaying(false), 500);
   };
+
+  const startTimeout = () => {
+    setIsInTimeout(true);
+    // Auto-advance to next note
+    const advanceTime = Math.min(autoAdvanceSpeed, 2); // Max 2 seconds for timeout
+    setTimeout(() => {
+      setIsInTimeout(false);
+    }, advanceTime * 1000);
+  }
 
   const handleNoteGuess = (guessedNote: NoteWithOctave) => {
     // If game is completed, allow piano playing but no game logic
@@ -170,6 +167,7 @@ const NoteIdentification: React.FC<NoteIdentificationProps> = ({ onGuessAttempt,
     setFeedback(result.feedback);
 
     if (isCorrect) {
+      startTimeout();
       stopTimer(); // Stop timer on correct guess
     }
 
@@ -236,6 +234,7 @@ const NoteIdentification: React.FC<NoteIdentificationProps> = ({ onGuessAttempt,
       setGameState(prevState => prevState ? { ...prevState } : prevState);
     } else {
       // Reset timer to full time for new round in non-Rush modes
+      console.log("Resetting timer.");
       resetTimer();
     }
 

--- a/src/components/NoteIdentification.tsx
+++ b/src/components/NoteIdentification.tsx
@@ -103,14 +103,14 @@ const NoteIdentification: React.FC<NoteIdentificationProps> = ({ onGuessAttempt,
     });
   }, []);
 
-  // Handle pause state changes for feedback
+  // Handle pause state changes
   useEffect(() => {
-    if (isPaused && isTimerActive) {
+    if (isPaused) {
       setFeedback('Game paused');
-    } else if (!isPaused && currentNote && !isTimerActive && !isInTimeout && gameState) {
+    } else if (currentNote && gameState && !isInTimeout) {
       setFeedback(gameState.getFeedbackMessage(true));
     }
-  }, [isPaused, isTimerActive, currentNote, isInTimeout, gameState]);
+  }, [isPaused]);
 
   const playCurrentNote = async () => {
     if (!currentNote) return;
@@ -262,7 +262,7 @@ const NoteIdentification: React.FC<NoteIdentificationProps> = ({ onGuessAttempt,
 
   // Start timer when currentNote changes and note finishes playing (but not if game is completed or in timeout)
   useEffect(() => {
-    const shouldStart = currentNote && !isPlaying && !isPaused && !isInTimeout && responseTimeLimit && gameState && !isGameCompleted && gameState.shouldStartTimer() && !isTimerActive;
+    const shouldStart = currentNote && !isPlaying && !isPaused && !isInTimeout && responseTimeLimit && gameState && !isGameCompleted && !isTimerActive;
 
     if (shouldStart) {
       startTimer();

--- a/src/components/modes/RushModeDisplay.tsx
+++ b/src/components/modes/RushModeDisplay.tsx
@@ -21,7 +21,11 @@ const RushModeDisplay: React.FC<RushModeDisplayProps> = ({
   onTimerUpdate
 }) => {
   // Initialize Rush timer (for Rush mode)
-  const { isTimerActive: isRushTimerActive, startTimer: startRushTimer } = useRushTimer({
+  const {
+    elapsedTime: rushElapsedTime,
+    isTimerActive: isRushTimerActive,
+    startTimer: startRushTimer
+  } = useRushTimer({
     isPaused,
     onTick: (time) => {
       if (onTimerUpdate) {
@@ -47,7 +51,7 @@ const RushModeDisplay: React.FC<RushModeDisplayProps> = ({
       {(currentNote || gameState.isCompleted) && (
         <div className="timer-section">
           <TimerCountUp
-            elapsedTime={gameState.isCompleted ? (gameState.completionTime || gameState.elapsedTime) : gameState.elapsedTime}
+            elapsedTime={gameState.isCompleted ? (gameState.completionTime || rushElapsedTime) : rushElapsedTime}
             isActive={isRushTimerActive && !gameState.isCompleted}
           />
           <div className="rush-progress">

--- a/src/game/GameStateFactory.tsx
+++ b/src/game/GameStateFactory.tsx
@@ -127,11 +127,6 @@ export class RushGameStateImpl implements RushGameState {
     }
   };
 
-  shouldStartTimer = (): boolean => {
-    // Rush mode uses count-up timer, so regular timer should not start
-    return false;
-  };
-
   getTimerMode = (): 'count-up' | 'count-down' | 'none' => {
     return 'count-up';
   };
@@ -199,11 +194,6 @@ export class SurvivalGameStateImpl implements SurvivalGameState {
     // TODO: Implement survival mode start round logic
   };
 
-  shouldStartTimer = (): boolean => {
-    // Survival mode uses count-down timer
-    return true;
-  };
-
   getTimerMode = (): 'count-up' | 'count-down' | 'none' => {
     return 'count-down';
   };
@@ -268,11 +258,6 @@ export class SandboxGameStateImpl implements SandboxGameState {
     // TODO: Implement sandbox mode start round logic
   };
 
-  shouldStartTimer = (): boolean => {
-    // Sandbox mode uses count-down timer
-    return true;
-  };
-
   getTimerMode = (): 'count-up' | 'count-down' | 'none' => {
     return 'count-down';
   };
@@ -289,7 +274,6 @@ export interface GameStateWithDisplay extends BaseGameState {
   // Hooks for game state to control behavior
   getFeedbackMessage: (currentNote: boolean) => string;
   onStartNewRound: () => void;
-  shouldStartTimer: () => boolean;
   getTimerMode: () => 'count-up' | 'count-down' | 'none';
 }
 

--- a/src/hooks/useGameTimer.ts
+++ b/src/hooks/useGameTimer.ts
@@ -38,7 +38,6 @@ export const useGameTimer = (options: GameTimerOptions): GameTimerReturn => {
 
   const startTimer = useCallback(() => {
     if (!timeLimit) return; // Unlimited time
-    
     clearTimers();
     setTimeRemaining(timeLimit);
     setIsTimerActive(true);


### PR DESCRIPTION
    Fix timers on Rush that would not increment.

    Fix issue where the note timer resets on correct guesses rather
    than after the next note is played.